### PR TITLE
build: use organisation prefix for npm package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "nlds-community-blocks",
+	"name": "@nl-design-system-community/nlds-community-blocks",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
@@ -7707,9 +7707,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
 			"integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
 			"dev": true,
-			"engines": [
-				"node >= 0.8.0"
-			],
+			"engines": ["node >= 0.8.0"],
 			"bin": {
 				"ansi-html": "bin/ansi-html"
 			}
@@ -13145,9 +13143,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
-			"os": [
-				"darwin"
-			],
+			"os": ["darwin"],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -20478,9 +20474,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
-			"os": [
-				"darwin"
-			],
+			"os": ["darwin"],
 			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-	"name": "nlds-community-blocks",
+	"name": "@nl-design-system-community/nlds-community-blocks",
 	"version": "1.0.0",
-	"description": "NL Design System Community Blocks.",
+	"description": "WordPress Gutenberg Blocks for NL Design System components. Use this so authors of WordPress websites can use NL Design System components to compose their pages.",
 	"license": "EUPL-1.2",
 	"author": "Acato",
 	"main": "build/index.js",
+	"keywords": [
+		"nl-design-system",
+		"wordpress",
+		"wordpress-plugin"
+	],
 	"contributors": [
 		{
 			"name": "Paul van Impelen",


### PR DESCRIPTION
- [x] Use `@nl-design-system-community/` instead of `@nl-design-system-unstable/`
- [x] Keep `nlds-community-blocks` as package name, to follow WordPress conventions (`nlds-community-blocks` for repo name, `nlds-community-blocks` for package name, `nlds-community-blocks.php` as entry file)