### PR TITLE
feat: add none option to loading of tokens

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -234,6 +234,9 @@ class Admin {
 			$nlds_community_blocks_municipalities[ $ncb_community ] = ucfirst( $ncb_community );
 		}
 
+		// Add a none option.
+		$nlds_community_blocks_municipalities['none'] = esc_html__( 'None', 'nlds-community-blocks' );
+
 		// Output the field.
 		foreach ( $nlds_community_blocks_municipalities as $value => $label ) {
 			echo '<label><input type="radio" name="ncb_municipality" value="' . esc_attr( $value ) . '" ' . checked( $value, $ncb_selected_municipality, false ) . '> ' . esc_html( $label ) . '</label><br/>';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -99,7 +99,7 @@ class Frontend {
 		}
 
 		$ncb_theme = esc_attr( get_option( 'ncb_municipality', 'denhaag' ) );
-		if ( ! empty( $ncb_theme ) && Plugin::has_resource( NCB_ABSPATH . NCB_ASSETS_DIR . "client/tokens/ncb-$ncb_theme-tokens.css" ) ) {
+		if ( ! empty( $ncb_theme ) && 'none' !== $ncb_theme && Plugin::has_resource( NCB_ABSPATH . NCB_ASSETS_DIR . "client/tokens/ncb-$ncb_theme-tokens.css" ) ) {
 			wp_enqueue_style(
 				"ncb-$ncb_theme-tokens",
 				ncb_mix( "client/tokens/ncb-$ncb_theme-tokens.css" ),


### PR DESCRIPTION
![Screenshot 2024-03-26 at 13 17 59](https://github.com/nl-design-system/nlds-community-blocks/assets/48315669/904ff9db-6fed-4e65-ad43-92c9219442b8)

- Adds a "None" option to the "Load tokens from: " option setting
- Choosing "None" skips the enqueuing of the tokens css