### PR TITLE
build: update GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,20 +12,20 @@ jobs:
 
         steps:
             - name: Download code from GitHub
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
             - name: Install pnpm package manager
-              uses: pnpm/action-setup@v2.4.0
+              uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
             - name: Set up Node.js version
-              uses: actions/setup-node@v4.0.1
+              uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
               with:
                   node-version-file: .nvmrc
                   cache: pnpm
 
             - name: Install dependencies
               run: |
-                  pnpm install
+                  pnpm install --frozen-lockfile
                   pnpm ls
 
     lint:
@@ -34,24 +34,22 @@ jobs:
 
         steps:
             - name: Download code from GitHub
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
             - name: Install pnpm package manager
-              uses: pnpm/action-setup@v2.4.0
+              uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
             - name: Set up Node.js version
-              uses: actions/setup-node@v4.0.1
+              uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
               with:
                   node-version-file: .nvmrc
                   cache: pnpm
 
             - name: Install dependencies
-              run: |
-                  pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: 'Continuous Integration: lint'
-              run: |
-                  pnpm run --if-present lint
+              run: pnpm run --if-present lint
 
     test:
         runs-on: ubuntu-latest
@@ -59,24 +57,22 @@ jobs:
 
         steps:
             - name: Download code from GitHub
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
             - name: Install pnpm package manager
-              uses: pnpm/action-setup@v2.4.0
+              uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
             - name: Set up Node.js version
-              uses: actions/setup-node@v4.0.1
+              uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
               with:
                   node-version-file: .nvmrc
                   cache: pnpm
 
             - name: Install dependencies
-              run: |
-                  pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: 'Continuous Integration: test'
-              run: |
-                  pnpm run --if-present test
+              run: pnpm run --if-present test
 
     build:
         runs-on: ubuntu-latest
@@ -84,29 +80,27 @@ jobs:
 
         steps:
             - name: Download code from GitHub
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
             - name: Install pnpm package manager
-              uses: pnpm/action-setup@v2.4.0
+              uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
             - name: Set up Node.js version
-              uses: actions/setup-node@v4.0.1
+              uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
               with:
                   node-version-file: .nvmrc
                   cache: pnpm
 
             - name: Install dependencies
-              run: |
-                  pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: 'Continuous Integration: build'
               env:
                   BASE_URL: '/utrecht/'
-              run: |
-                  pnpm run --if-present build
+              run: pnpm run --if-present build
 
             - name: 'Retain build artifact: build'
-              uses: actions/upload-artifact@v4.3.0
+              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
               with:
                   name: nlds-community-blocks
                   path: '@nl-design-system-community/nlds-community-blocks.zip'
@@ -119,12 +113,12 @@ jobs:
 
         steps:
             - name: 'Restore build artifact: build'
-              uses: actions/download-artifact@v4.1.1
+              uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
               with:
                   name: nlds-community-blocks
                   path: '@nl-design-system-community/nlds-community-blocks.zip'
 
-            - uses: marvinpinto/action-automatic-releases@latest
+            - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
               with:
                   repo_token: '${{ secrets.GITHUB_TOKEN }}'
                   automatic_release_tag: 'latest'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,10 @@ jobs:
 
         steps:
             - name: Checkout branch
-              uses: actions/checkout@v3
+              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
             - name: Install dependencies
-              uses: php-actions/composer@v6
+              uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
               with:
                   php_version: ${{ matrix.php_version }}
                   version: '2.x'

--- a/.github/workflows/require-autosquash-fixup-commits.yml
+++ b/.github/workflows/require-autosquash-fixup-commits.yml
@@ -13,6 +13,6 @@ jobs:
 
         steps:
             - name: Require `git rebase --autosquash` for `--fixup` commits
-              uses: xt0rted/block-autosquash-commits-action@v2.2.0
+              uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update actions to their latest versions and uses hashes to prevent tampering. Dependabot will pick this up and create PRs for future updates accordingly.

Add `--frozen-lockfile` to `pnpm install` to make it explicit what happens in CI.